### PR TITLE
Sign in page styling

### DIFF
--- a/src/Components/Svgs/Footer.tsx
+++ b/src/Components/Svgs/Footer.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 export default function Footer() {
   return (
-    <div className="h-auto flex flex-row justify-between items-center w-full p-4 bg-shell-75 mt-2">
+    <div className="h-auto flex flex-row justify-between items-center w-full p-4 bg-shell-75 ">
       {/* Left Section */}
       <div className="flex flex-row items-center text-bluestone-200 gap-3 sm:gap-6 md:gap-12">
         {/* Contact Block */}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,12 +42,25 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <Toaster position="top-right" closeButton richColors />
-        <ClerkProvider publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}>
+        <ClerkProvider
+          publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+          localization={{
+            signIn: {
+              start: {
+                // title: "Hi there",
+                subtitle: "To continue as Guest, close this modal.",
+                actionText: "Don't have account?",
+              },
+            },
+          }}
+        >
           <TournamentsAndQueuesProvider>
             <FavouriteItemsProvider>
               <SocketProvider>
-                <div className="flex flex-col min-h-screen">
-                  <main className="flex-1">{children}</main>
+                <div className="flex flex-col h-screen">
+                  <main className="flex-1  flex-row justify-center content-center ">
+                    {children}
+                  </main>
                   <Footer />
                 </div>
               </SocketProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -48,7 +48,7 @@ export default function RootLayout({
             signIn: {
               start: {
                 // title: "Hi there",
-                subtitle: "To continue as Guest, close this modal.",
+                subtitle: "To continue as a Guest, close this modal.",
                 actionText: "Don't have account?",
               },
             },

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,14 @@
 "use client";
+import { useEffect, useRef } from "react";
+import {
+  useClerk,
+  SignInButton,
+  SignedIn,
+  SignedOut,
+  UserButton,
+  useUser,
+} from "@clerk/nextjs";
 
-import { useEffect } from "react";
-import { SignInButton, SignedIn, SignedOut, UserButton, useUser } from "@clerk/nextjs";
 // to redirect the user to a specific route after logginin
 import { useRouter } from "next/navigation";
 import { useFavourites } from "@/context/FavouriteItemsContext";
@@ -9,8 +16,32 @@ import Link from "next/link";
 
 export default function LoginPage() {
   const router = useRouter();
-  const { isSignedIn, user } = useUser();
+  const { isSignedIn, user, isLoaded } = useUser();
   const { addUser } = useFavourites();
+
+  const { openSignIn } = useClerk();
+  const opened = useRef(false);
+
+  useEffect(() => {
+    if (!isLoaded) return;
+    if (opened.current) return;
+    if (isSignedIn) return;
+    {
+      opened.current = true;
+
+      openSignIn({
+        afterSignInUrl: "/",
+        afterSignUpUrl: "/",
+
+        appearance: {
+          elements: {
+            modalBackdrop: "z-[60] bg-black/60 backdrop-blur-sm",
+            modalContent: "z-[80] rounded-2xl shadow-2xl",
+          },
+        },
+      });
+    }
+  }, [openSignIn]);
 
   useEffect(() => {
     if (isSignedIn) {
@@ -24,20 +55,26 @@ export default function LoginPage() {
   }, [isSignedIn, user]);
 
   return (
-    <div className="flex items-center justify-center">
-      <div className="flex flex-col items-center p-8 rounded-lg shadow-lg max-w-md w-full">
-        <SignedIn>
-          <UserButton />
-        </SignedIn>
-        <SignedOut>
-          <h2 className="text-3xl font-bold text-center text-bluestone-300 mb-6">Sign In</h2>
-          <div className="flex items-center justify-center cursor-pointer bg-tennis-200 text-bluestone-300 px-6 py-3 rounded-lg shadow-lg hover:bg-tennis-100 transition duration-300 ease-in-out transform hover:scale-105">
-            <SignInButton>Click to Sign In</SignInButton>
-          </div>
-        </SignedOut>
+    <div className="flex flex-col h-full justify-center items-center bg-black bg-opacity-60 backdrop-blur-sm ">
+      <div className="flex flex-col items-center gap-6 p-8 rounded-2xl border border-cyan-400 bg-white/10 backdrop-blur-md shadow-2xl max-w-md w-full transition-all duration-300 hover:border-cyan-300 hover:shadow-cyan-200/30">
+        <div className="flex items-center gap-4">
+          <SignedIn>
+            <UserButton />
+          </SignedIn>
+          <SignedOut>
+            <SignInButton
+              mode="modal"
+              className="flex items-center justify-center cursor-pointer bg-tennis-200 text-bluestone-300 px-6 py-3 rounded-lg shadow-lg hover:bg-tennis-100 transition duration-300 ease-in-out transform hover:scale-105"
+            >
+              Sign In
+            </SignInButton>
+          </SignedOut>
+        </div>
         <Link
           href="/"
-          className="flex my-6 text-bluestone-300 no-underline hover:text-bluestone-100 hover:underline"
+          className=" mx-auto w-max
+                   px-4 py-2 text-sm font-medium text-white/90
+                   bg-black/60 rounded-full backdrop-blur-md hover:text-white"
         >
           Continue as a Guest
         </Link>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -55,8 +55,8 @@ export default function LoginPage() {
   }, [isSignedIn, user]);
 
   return (
-    <div className="flex flex-col h-full justify-center items-center bg-black bg-opacity-60 backdrop-blur-sm ">
-      <div className="flex flex-col items-center gap-6 p-8 rounded-2xl border border-cyan-400 bg-white/10 backdrop-blur-md shadow-2xl max-w-md w-full transition-all duration-300 hover:border-cyan-300 hover:shadow-cyan-200/30">
+    <div className="flex flex-col h-full justify-center items-center bg-shell75 bg-opacity-60 backdrop-blur-sm ">
+      <div className="flex flex-col items-center gap-6 p-8 rounded-2xl border border-cyan-400 bg-bluestone-200 backdrop-blur-md shadow-2xl max-w-md w-full transition-all duration-300 hover:border-cyan-300 hover:shadow-cyan-200/30">
         <div className="flex items-center gap-4">
           <SignedIn>
             <UserButton />


### PR DESCRIPTION
Notion TIcket ID: 250429-3ff47

i implemented the clerk login UI into the app, that way we dont get redirected to an external Clerk website.
Not feeling disconnected from app --> better user experience.

Modal shows up when logged out, and automatically opens when going on loginPage.

Subtitle in Modal : To continue as a Guest, close this modal. -->Click on X you are back on the app with SignIn / Continue as Guest Buttons.

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/264b8894-a6ba-49c2-a59d-9977c4153e11" /><img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/cd465f26-e91f-4c78-a0dc-300a3aaf8ab1" />
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/1ff07478-8a6e-419f-b332-10a9b8b952ca" />
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/a569a02d-4264-4ffb-ae0a-672f01947b48" />
