### PR TITLE
Image edit button page

### DIFF
--- a/src/app/all-tournaments/[...id]/page.tsx
+++ b/src/app/all-tournaments/[...id]/page.tsx
@@ -20,6 +20,7 @@ export default function TournamentPage() {
   const [pendingImage, setPendingImage] = useState<File | null>(null);
 
   const qrRef = useRef(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
   const { currentTournament, setCurrentTournament, tournamentOwner, currentTournamentRef } =
     useTournamentsAndQueuesContext();
 
@@ -54,7 +55,7 @@ export default function TournamentPage() {
     // cleanup old preview
     if (previewUrl) URL.revokeObjectURL(previewUrl);
 
-    setPendingImage(file); 
+    setPendingImage(file);
     const objectUrl = URL.createObjectURL(file);
     setPreviewUrl(objectUrl);
   }

--- a/src/app/all-tournaments/[...id]/page.tsx
+++ b/src/app/all-tournaments/[...id]/page.tsx
@@ -16,6 +16,8 @@ import { faPencil, faTrash, faQrcode } from "@fortawesome/free-solid-svg-icons";
 export default function TournamentPage() {
   const [editMode, toggleEditMode] = useState(false);
   const [showQR, setShowQR] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [pendingImage, setPendingImage] = useState<File | null>(null);
 
   const qrRef = useRef(null);
   const { currentTournament, setCurrentTournament, tournamentOwner, currentTournamentRef } =
@@ -44,8 +46,55 @@ export default function TournamentPage() {
   const inputStyles =
     "rounded focus:outline-blue focus:ring-2 focus:ring-brick-200 py-1 px-2 border-2 border-gray-300";
 
+  //on handle change for changing tournamend image
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // cleanup old preview
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+
+    setPendingImage(file); 
+    const objectUrl = URL.createObjectURL(file);
+    setPreviewUrl(objectUrl);
+  }
+
   async function handleSave() {
     if (!currentTournament?._id) return;
+
+    console.log(currentTournament._id);
+    let imageUrl: string | null =
+      typeof currentTournament.image === "string" ? currentTournament.image : null;
+
+    if (pendingImage instanceof File) {
+      const file = pendingImage;
+      const fileType = file.type || "application/octet-stream";
+      const res = await fetch(
+        `/api/gcs-uploads?fileName=${encodeURIComponent(file.name)}&fileType=${encodeURIComponent(fileType)}`
+      );
+
+      console.log(res);
+      const { uploadUrl, publicUrl } = await res.json();
+
+      try {
+        const putRes = await fetch(uploadUrl, {
+          method: "PUT",
+          headers: { "Content-Type": fileType },
+          body: file,
+        });
+        if (!putRes.ok) {
+          const errText = await putRes.text().catch(() => "");
+          throw new Error(`Upload failed: ${putRes.status}${putRes.statusText} ${errText}`);
+        }
+      } catch (err) {
+        console.error("GCS PUT failed:", err);
+      }
+
+      imageUrl = publicUrl;
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+      setPreviewUrl(null);
+      setPendingImage(null);
+    }
 
     try {
       const response = await fetch(`/api/tournament/${currentTournament._id}`, {
@@ -56,6 +105,7 @@ export default function TournamentPage() {
         body: JSON.stringify({
           name: editedName,
           categories: editedCategories,
+          ...(imageUrl ? { image: imageUrl } : {}),
         }),
       });
 
@@ -65,6 +115,7 @@ export default function TournamentPage() {
 
       const updatedTournament = await response.json();
 
+      console.log(updatedTournament);
       setCurrentTournament(updatedTournament);
 
       toggleEditMode(false);
@@ -156,12 +207,44 @@ export default function TournamentPage() {
               </div>
             )}
             {editMode ? (
-              <Button
-                className="mx-2 px-3 text-[0.75rem] font-semibold rounded text-shell-100 bg-brick-200 hover:bg-tennis-50 hover:text-shell-300 transition-colors duration-200 ease-in-out "
-                onClick={handleSave}
-              >
-                Save
-              </Button>
+              <div>
+                {}
+                <Button
+                  className="mx-2 px-3 text-[0.75rem] font-semibold rounded text-shell-100 bg-brick-200 hover:bg-tennis-50 hover:text-shell-300 transition-colors duration-200 ease-in-out "
+                  onClick={handleSave}
+                >
+                  Save
+                </Button>
+                <label htmlFor="image">
+                  <button
+                    type="button"
+                    onClick={() => inputRef.current?.click()}
+                    className="bg-gray-200 items-center cursor-pointer rounded-md shadow hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-400 transition-all duration-150 text-sm p-2"
+                  >
+                    Choose Image
+                  </button>
+                  <div>
+                    {previewUrl && (
+                      <div className="flex flex-col items-center">
+                        <p className="text-sm text-gray-600">Image Preview:</p>
+                        <img
+                          className="rounded-md w-48 h-32 object-cover border border-gray-300 mb-2 text-sm text-gray-600"
+                          src={previewUrl}
+                          alt="Tournament Preview"
+                        />
+                      </div>
+                    )}
+                  </div>
+                </label>
+                <input
+                  type="file"
+                  name="image"
+                  accept="image/*"
+                  ref={inputRef}
+                  hidden
+                  onChange={handleChange}
+                />
+              </div>
             ) : (
               <Button
                 className="px-2 py-2 text-[0.75rem] text-lg ml-4 transform transition-transform duration-150 hover:-translate-y-0.5 ease-in-out overflow-visible"


### PR DESCRIPTION
Notion-ticket: 251008-3c9b7
Added "Choose Image" button to edit image on tournament page.

<img width="1897" height="635" alt="image" src="https://github.com/user-attachments/assets/d71b480b-0a21-4f93-b101-34cbb2bd0268" />

<img width="982" height="313" alt="Screenshot 2025-10-14 161906" src="https://github.com/user-attachments/assets/69da579c-181f-44b9-a184-76ed09295a22" />

please see try-catch block in GCS function.
Devtools error message says GCS service account rejects acces to upload images etc.
That could also be the reason why we cant add images while creating a new tournament.

<img width="1920" height="1032" alt="Screenshot 2025-10-18 125725" src="https://github.com/user-attachments/assets/2ea8aa41-ea97-4dfb-8227-f3b019752fb4" />

<img width="814" height="96" alt="image" src="https://github.com/user-attachments/assets/918f5d9c-5fad-4e71-aef8-f6ef9ab30bf5" />

<img width="540" height="213" alt="image" src="https://github.com/user-attachments/assets/fd82e851-6fc9-49ed-ad4a-38032fb1e9b2" />

