### PR TITLE
show addAllButton only when isSignedIn

### DIFF
--- a/src/Components/PlayersList.tsx
+++ b/src/Components/PlayersList.tsx
@@ -4,6 +4,8 @@
 import { useState, useEffect, useRef } from "react";
 import { useTournamentsAndQueuesContext } from "@/context/TournamentsAndQueuesContext";
 import { useSocket } from "@/context/SocketContext";
+//clerk
+import { useUser } from "@clerk/nextjs";
 
 // components
 import DropZone from "./DropZone";
@@ -74,23 +76,27 @@ export default function PlayersList({
     }
   };
 
+  const { isSignedIn } = useUser();
+
   return (
     <div id="modal-root">
       <div className="flex flex-col items-center">
         <SectionHeader>{title}</SectionHeader>
-        <Button
-          className="mt-2 bg-bluestone-200 border-2 border-transparent hover:bg-tennis-200 text-shell-50 hover:text-shell-300 py-2 h-fit w-fit px-4 rounded text-nowrap font-bold hover:border-2 hover:border-bluestone-200"
-          onClick={() => {
-            if (socket) {
-              socket.emit("addAllFromOneList", {
-                tournament: currentTournament,
-                listName: title,
-              });
-            }
-          }}
-        >
-          Add All
-        </Button>
+        {isSignedIn && (
+          <Button
+            className="mt-2 bg-bluestone-200 border-2 border-transparent hover:bg-tennis-200 text-shell-50 hover:text-shell-300 py-2 h-fit w-fit px-4 rounded text-nowrap font-bold hover:border-2 hover:border-bluestone-200"
+            onClick={() => {
+              if (socket) {
+                socket.emit("addAllFromOneList", {
+                  tournament: currentTournament,
+                  listName: title,
+                });
+              }
+            }}
+          >
+            Add All
+          </Button>
+        )}
       </div>
 
       <div className="flex flex-col shadow-left-bottom-lg items-center h-auto overflow-hidden hover:overflow-y-auto w-full mt-3 p-4 rounded-lg">


### PR DESCRIPTION
NotionTicket NR:251018-53bae

- [x] For users that are not logged in we still display the add all button. This needs to be hidden

works with object destructuring from useUser() and Conditional rendering. 
see pictures below

Incorrect shown button when not logged in.
<img width="1591" height="976" alt="image" src="https://github.com/user-attachments/assets/aee3f82b-d433-43c4-8004-b6c22f188db7" />
**BugFix Button hidden when not logged in.**
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/76e852b5-1ffc-40f6-bd75-6fbb091b0691" />

**BugFix button shown when logged in.**
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/398e8442-3591-4cc2-9b1c-5efc83ffac2b" />

